### PR TITLE
Run explicit package check, use sum() of length() as return code

### DIFF
--- a/.github/workflows/r2u.yaml
+++ b/.github/workflows/r2u.yaml
@@ -50,4 +50,19 @@ jobs:
           if (length(md) > 1L) md <- md[1L]
           cat("** Testing file", md, "\n")
           ok <- length(md) == 1L && file.exists(md)
-          q("no", status = as.integer(!ok))
+          # TRUE is success and returned as zero
+          q("no", status = as.integer(!ok))  
+
+      - name: Run an existence test for main .md file
+        shell: Rscript {0}
+        run: |
+          md <- paste0(basename(getwd()), ".md")
+          if (!file.exists(md)) md <- setdiff(Sys.glob("*.md"), "README.md")
+          if (length(md) > 1L) md <- md[1L]
+          res <- ctv::check_ctv_packages(md)
+          res <- Filter(length, res)
+          str(res)
+          pkgs <- sum(lengths(res))
+          # Zero packages to adjust is success 
+          q("no", status = as.integer(pkgs))  
+          

--- a/.github/workflows/r2u.yaml
+++ b/.github/workflows/r2u.yaml
@@ -38,31 +38,32 @@ jobs:
         shell: Rscript {0}
         run: install.packages(c("ctv", "knitr", "rmarkdown"))
 
-      - name: Convert ctv File(s) to html
-        shell: Rscript {0}
-        run: sapply(dir(pattern="\\.md"), ctv::ctv2html)
-
-      - name: Run an existence test for main .md file
+      - name: Set File Name
         shell: Rscript {0}
         run: |
           md <- paste0(basename(getwd()), ".md")
           if (!file.exists(md)) md <- setdiff(Sys.glob("*.md"), "README.md")
           if (length(md) > 1L) md <- md[1L]
-          cat("** Testing file", md, "\n")
-          ok <- length(md) == 1L && file.exists(md)
+          cat(paste0("MD=", md, "\n"), file=Sys.getenv("GITHUB_ENV"), append=TRUE)
+
+      - name: Run an existence test for main .md file
+        shell: Rscript {0}
+        run: |
+          ok <- file.exists(Sys.getenv("MD"))
           # TRUE is success and returned as zero
           q("no", status = as.integer(!ok))  
+          
+      - name: Convert ctv File from md to html
+        shell: Rscript {0}
+        run: ctv::ctv2html(Sys.getenv("MD"))
 
-      - name: Run an existence test for main .md file
+      - name: Run package check on
         shell: Rscript {0}
         run: |
-          md <- paste0(basename(getwd()), ".md")
-          if (!file.exists(md)) md <- setdiff(Sys.glob("*.md"), "README.md")
-          if (length(md) > 1L) md <- md[1L]
-          res <- ctv::check_ctv_packages(md)
+          res <- ctv::check_ctv_packages(Sys.getenv("MD"))
           res <- Filter(length, res)
           str(res)
-          pkgs <- sum(lengths(res))
-          # Zero packages to adjust is success 
-          q("no", status = as.integer(pkgs))  
+          # Zero packages to adjust is success; zero is shell success
+          # Any non-zero number is failure and 'work to do'
+          q("no", status = as.integer(sum(lengths(res))))  
           

--- a/ctv-gha-demo.full.md
+++ b/ctv-gha-demo.full.md
@@ -11,6 +11,10 @@ A core package: `r pkg("Rcpp", priority = "core")`.
 
 A standard package: `r pkg("RcppArmadillo")`.
 
+An archived package: `r pkg("RcppOctave")` but available on GitHub at `r github("cran/RcppOctave")`.
+
+A unavailable package: `r pkg("RcppPython")` with unavailable GitHub link `r github("cran/RcppPython")`.
+
 
 ### Links
 - R Project correct link: [R-project.org](https://www.R-project.org/)


### PR DESCRIPTION
This simple PR adds a package check for the given ctv [^1] and fails if any of the four reported conditions have entries.  I am using `Filter()` here to be cute to remove the entryless parts [^2] and then am equally cute to rely on `str()` for a more compact printing of the `list` object.


[^1]: Recomputing the desired file is clumsy.  On can pass the result of one step around to other steps, but only in a clumsy way via environment variables.  I will send a PR that cleans that up in a day or two; for now we can just live with the wart and focus on the package check.
[^2]: I am generally 'Team `lapply` / `sapply` for everything' but sometimes I remember these functions.