### PR TITLE
Setup action

### DIFF
--- a/validate-ctv/README.md
+++ b/validate-ctv/README.md
@@ -31,6 +31,8 @@ name: Validate task view
 jobs:
   validate-ctv:
     runs-on: ubuntu-latest
+    container:
+      image: rocker/r2u:latest
     steps:
       - uses: eddelbuettel/ctv-gha-demo/validate-ctv@master
 ```

--- a/validate-ctv/README.md
+++ b/validate-ctv/README.md
@@ -32,7 +32,7 @@ jobs:
   validate-ctv:
     runs-on: ubuntu-latest
     steps:
-      - uses: eddelbuettel/ctv-gha-demo/validate-ctv@main
+      - uses: eddelbuettel/ctv-gha-demo/validate-ctv@master
 ```
 
 Replace `<TaskViewName>` with the name of the task view. Typically, the task view

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -10,6 +10,7 @@ runs:
       run: sessionInfo()
 
     - name: System dependencies
+      shell: bash
       # can be used to install e.g. cmake or other build dependencies
       run: apt update -qq && apt install --yes --no-install-recommends pandoc
 

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -5,8 +5,6 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v5
-    
-    - uses: r-lib/actions/setup-r@v2
 
     - name: SessionInfo
       shell: Rscript {0}

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -2,6 +2,7 @@ name: Validate CRAN Task View
 description: Validate the md file in a GitHub repository for a CRAN Task View
 
 runs:
+  using: 'composite'
   steps:
     - uses: actions/checkout@v5
 

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -5,6 +5,8 @@ runs:
   using: 'composite'
   steps:
     - uses: actions/checkout@v5
+    
+    - uses: r-lib/actions/setup-r@v2
 
     - name: SessionInfo
       shell: Rscript {0}

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -1,5 +1,6 @@
 name: Validate CRAN Task View
 description: Validate the md file in a GitHub repository for a CRAN Task View
+author: CRAN Task View Initiative
 
 runs:
   using: 'composite'

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -1,85 +1,75 @@
 name: Validate CRAN Task View
 description: Validate the md file in a GitHub repository for a CRAN Task View
 
-on:
-  push:
-  pull_request:
-  release:
-  workflow_dispatch:
+runs:
+  using: 'composite'
 
-jobs:
-  ci:
-    runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v5
 
-    container:
-      image: rocker/r2u:latest
+    - name: SessionInfo
+      shell: Rscript {0}
+      run: sessionInfo()
 
-    steps:
-      - uses: actions/checkout@v5
+    - name: System dependencies
+      # can be used to install e.g. cmake or other build dependencies
+      run: apt update -qq && apt install --yes --no-install-recommends pandoc
 
-      - name: SessionInfo
-        shell: Rscript {0}
-        run: sessionInfo()
+    - name: Install ctv package and dependencies
+      shell: Rscript {0}
+      run: install.packages(c("ctv", "knitr", "rmarkdown", "RCurl"))
 
-      - name: System dependencies
-        # can be used to install e.g. cmake or other build dependencies
-        run: apt update -qq && apt install --yes --no-install-recommends pandoc
+    - name: Query and set name of main .md file
+      shell: Rscript {0}
+      run: |
+        md <- paste0(basename(getwd()), ".md")
+        if (!file.exists(md)) md <- setdiff(Sys.glob("*.md"), "README.md")
+        if (length(md) > 1L) md <- md[1L]
+        cat(paste0("MD=", md, "\n"), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
 
-      - name: Install ctv package and dependencies
-        shell: Rscript {0}
-        run: install.packages(c("ctv", "knitr", "rmarkdown", "RCurl"))
+    - name: Run existence test for main .md file
+      shell: Rscript {0}
+      run: |
+        ok <- file.exists(Sys.getenv("MD"))
+        # TRUE is success and returned as status zero
+        q("no", status = as.integer(!ok))
+        
+    - name: Check that .md file can be read as ctv
+      shell: Rscript {0}
+      run: |
+        ctv <- try(ctv::read.ctv(Sys.getenv("MD")))
+        ok <- inherits(ctv, "ctv")
+        if (ok) cat(paste0("CTV=", ctv$name, "\n"), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+        q("no", status = as.integer(!ok))
+        
+    - name: Convert .md file to .html
+      shell: Rscript {0}
+      run: |
+        html <- ctv::ctv2html(Sys.getenv("MD"))
+        ok <- is.character(html)
+        q("no", status = as.integer(!ok))
 
-      - name: Query and set name of main .md file
-        shell: Rscript {0}
-        run: |
-          md <- paste0(basename(getwd()), ".md")
-          if (!file.exists(md)) md <- setdiff(Sys.glob("*.md"), "README.md")
-          if (length(md) > 1L) md <- md[1L]
-          cat(paste0("MD=", md, "\n"), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-
-      - name: Run existence test for main .md file
-        shell: Rscript {0}
-        run: |
-          ok <- file.exists(Sys.getenv("MD"))
-          # TRUE is success and returned as status zero
-          q("no", status = as.integer(!ok))
-          
-      - name: Check that .md file can be read as ctv
-        shell: Rscript {0}
-        run: |
-          ctv <- try(ctv::read.ctv(Sys.getenv("MD")))
-          ok <- inherits(ctv, "ctv")
-          if (ok) cat(paste0("CTV=", ctv$name, "\n"), file = Sys.getenv("GITHUB_ENV"), append = TRUE)
-          q("no", status = as.integer(!ok))
-          
-      - name: Convert .md file to .html
-        shell: Rscript {0}
-        run: |
-          html <- ctv::ctv2html(Sys.getenv("MD"))
-          ok <- is.character(html)
-          q("no", status = as.integer(!ok))
-
-      - name: Check for unavailable or archived packages
-        shell: Rscript {0}
-        run: |
-          chck <- ctv::check_ctv_packages(Sys.getenv("MD"))
-          unavailable <- chck[[3]]
-          archived <- chck[[4]]
-          cran_ctv <- try(ctv::ctv(Sys.getenv("CTV")), silent = TRUE)
-          if (!inherits(cran_ctv, "try-error")) archived <- setdiff(archived, cran_ctv$archived)
-          ok <- c(length(unavailable), length(archived)) == 0L
-          if (!ok[1]) cat(sprintf("Packages unavailable on CRAN: %s\n", paste(unavailable, collapse = ", ")))
-          if (!ok[2]) cat(sprintf("Added packages archived on CRAN: %s\n", paste(archived, collapse = ", ")))
-          q("no", status = as.integer(any(!ok)))
-          
-      - name: Check for unavailable links
-        shell: Rscript {0}
-        run: |
-          ctv <- ctv::read.ctv(Sys.getenv("MD"))
-          links <- unlist(ctv[c("links", "otherlinks")])
-          urls <- sub(".*href=\"(.*)\".*", "\\1", links)
-          urls <- urls[!RCurl::url.exists(urls)]
-          ok <- length(urls) == 0L
-          if (!ok) cat(sprintf("Unavailable links:\n%s\n", paste(urls, collapse = "\n")))
-          q("no", status = as.integer(!ok))
+    - name: Check for unavailable or archived packages
+      shell: Rscript {0}
+      run: |
+        chck <- ctv::check_ctv_packages(Sys.getenv("MD"))
+        unavailable <- chck[[3]]
+        archived <- chck[[4]]
+        cran_ctv <- try(ctv::ctv(Sys.getenv("CTV")), silent = TRUE)
+        if (!inherits(cran_ctv, "try-error")) archived <- setdiff(archived, cran_ctv$archived)
+        ok <- c(length(unavailable), length(archived)) == 0L
+        if (!ok[1]) cat(sprintf("Packages unavailable on CRAN: %s\n", paste(unavailable, collapse = ", ")))
+        if (!ok[2]) cat(sprintf("Added packages archived on CRAN: %s\n", paste(archived, collapse = ", ")))
+        q("no", status = as.integer(any(!ok)))
+        
+    - name: Check for unavailable links
+      shell: Rscript {0}
+      run: |
+        ctv <- ctv::read.ctv(Sys.getenv("MD"))
+        links <- unlist(ctv[c("links", "otherlinks")])
+        urls <- sub(".*href=\"(.*)\".*", "\\1", links)
+        urls <- urls[!RCurl::url.exists(urls)]
+        ok <- length(urls) == 0L
+        if (!ok) cat(sprintf("Unavailable links:\n%s\n", paste(urls, collapse = "\n")))
+        q("no", status = as.integer(!ok))
 

--- a/validate-ctv/action.yml
+++ b/validate-ctv/action.yml
@@ -2,8 +2,6 @@ name: Validate CRAN Task View
 description: Validate the md file in a GitHub repository for a CRAN Task View
 
 runs:
-  using: 'composite'
-
   steps:
     - uses: actions/checkout@v5
 


### PR DESCRIPTION
This has been tested in MissingData and it works. However, this involves asking people using validate-ctv to propagate this commit:

https://github.com/eddelbuettel/ctv-gha-demo/commit/d37e0dc0a058ec592f06d1a2c817a6aa4b733c07

in their repository. In clear: if we directly push the current action in CTV, that will result in errors for all people currently using ctv-validate. So next steps will be:

1. Incorporate the changes in ctv repository (be careful to change the URL in validate-ctv.yml to reference CTV action and not action in Dirk's repository).
2. Inform users? @zeileis What do you think? Do we have a way to do it easily?
3. (only for me but I put it here to not forget) Clean the mess in MissingData repository

Unsolved questions: @zeileis ?
1. We previously had an option to turn off system settings: I guess that we remove this option?
2. Do we entirely remove the Author field?